### PR TITLE
Integrate wandb image logging and hyperparameter tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ artifacts/*
 
 wandb/*
 
+imgui.ini
+
 # C extensions
 *.so
 
@@ -136,5 +138,6 @@ dmypy.json
 
 .idea
 /logs/
+/tb_logs/
 /results/
 /ckpts/

--- a/datasets/scannet.py
+++ b/datasets/scannet.py
@@ -17,6 +17,8 @@ class ScanNetDataset(BaseDataset):
         super().__init__(root_dir, split, downsample)
 
         self.unpad = 24
+        self.num_frames_train = kwargs.get('num_frames_train', 800)
+        self.num_frames_test = kwargs.get('num_frames_test', 80)
 
         self.read_intrinsics()
 
@@ -38,11 +40,11 @@ class ScanNetDataset(BaseDataset):
         if split == 'train':
             with open(os.path.join(self.root_dir, "train.txt"), 'r') as f:
                 frames = f.read().strip().split()
-                frames = frames[:800]
+                frames = frames[:self.num_frames_train]
         else:
             with open(os.path.join(self.root_dir, f"{split}.txt"), 'r') as f:
                 frames = f.read().strip().split()
-                frames = frames[:80]
+                frames = frames[:self.num_frames_test]
 
         cam_bbox = np.loadtxt(os.path.join(self.root_dir, f"cam_bbox.txt"))
         sbbox_scale = (cam_bbox[1] - cam_bbox[0]).max() + 2 * SCANNET_FAR

--- a/opt.py
+++ b/opt.py
@@ -6,7 +6,7 @@ def get_opts():
     # dataset parameters
     parser.add_argument('--root_dir', type=str, required=True,
                         help='root directory of dataset')
-    parser.add_argument('--dataset_name', type=str, default='nsvf',
+    parser.add_argument('--dataset_name', type=str, default='scannet',
                         choices=['nerf', 'nsvf', 'colmap', 'nerfpp', 'rtmv', 'scannet', 'google_scanned'],
                         help='which dataset to train/test')
     parser.add_argument('--split', type=str, default='train',
@@ -29,6 +29,10 @@ def get_opts():
     # training options
     parser.add_argument('--batch_size', type=int, default=8192,
                         help='number of rays in a batch')
+    parser.add_argument('--num_frames_train', type=int, default=800,
+                        help='amount of frames randomly samples from each scene sequence for training')
+    parser.add_argument('--num_frames_test', type=int, default=80,
+                        help='amount of frames randomly samples from each scene sequence for testing')
     parser.add_argument('--ray_sampling_strategy', type=str, default='all_images',
                         choices=['all_images', 'same_image'],
                         help='''
@@ -61,14 +65,22 @@ def get_opts():
     parser.add_argument('--exp_name', type=str, default='exp',
                         help='experiment name')
     parser.add_argument('--ckpt_path', type=str, default=None,
-                        help='pretrained checkpoint to load (including optimizers, etc)')
+                        help='''pretrained checkpoint to load (including optimizers, etc).
+                        Use if want to continue training''')
     parser.add_argument('--weight_path', type=str, default=None,
-                        help='pretrained checkpoint to load (excluding optimizers, etc)')
+                        help='''pretrained checkpoint to load (excluding optimizers, etc). 
+                        Use if want to run inference only''')
 
     # logging parameters
-    parser.add_argument('--save_video', type=str, default=False,
+    parser.add_argument('--save_video', action='store_true', default=False,
                         help='''create video from test images and save it. 
                         Makes no sense for random non-sequential images from ScanNet
                         ''')
     
+    parser.add_argument('--debug', action='store_true', default=False,
+                        help='if debug is enabled, wandb is not used for logging (default: False)')
+    parser.add_argument('--use_sweep', action='store_true', default=False,
+                        help='use wandb sweep agents for hyperparameter tuning (default: False)')
+    
+    # hyperparameter tuninig
     return parser.parse_args()

--- a/opt.py
+++ b/opt.py
@@ -65,4 +65,10 @@ def get_opts():
     parser.add_argument('--weight_path', type=str, default=None,
                         help='pretrained checkpoint to load (excluding optimizers, etc)')
 
+    # logging parameters
+    parser.add_argument('--save_video', type=str, default=False,
+                        help='''create video from test images and save it. 
+                        Makes no sense for random non-sequential images from ScanNet
+                        ''')
+    
     return parser.parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ jupyter
 scipy
 pymcubes
 trimesh
-dearpygui
+wandb
+taichi

--- a/show_gui.py
+++ b/show_gui.py
@@ -95,8 +95,8 @@ class NGPGUI:
         directions = get_ray_directions(self.cam.H, self.cam.W, self.cam.K, device='cuda')
         rays_o, rays_d = get_rays(directions, torch.cuda.FloatTensor(self.cam.pose))
 
-        # TODO: set these attributes by gui
-        if self.hparams.dataset_name in ['colmap', 'nerfpp']:
+        # TODO: set these attributes by gui?
+        if self.hparams.dataset_name in ['scannet'] and self.hparams.scale > 0.5:
             exp_step_factor = 1/256
         else: exp_step_factor = 0
 

--- a/show_gui.py
+++ b/show_gui.py
@@ -52,7 +52,7 @@ class OrbitCamera:
     def reset(self, pose=None):
         self.rot = np.eye(3)
         self.center = np.zeros(3)
-        self.radius = 2.0
+        self.radius = 0.05
         if pose is not None:
             self.rot = pose.cpu().numpy()[:3, :3]
 
@@ -71,7 +71,7 @@ class OrbitCamera:
 
 
 class NGPGUI:
-    def __init__(self, hparams, K, img_wh, poses, radius=2.5):
+    def __init__(self, hparams, K, img_wh, poses, radius=0.5):
         self.hparams = hparams
         #rgb_act = 'None' if self.hparams.use_exposure else 'Sigmoid'
         self.model = NeRFusion2(scale=hparams.scale).cuda()
@@ -105,7 +105,7 @@ class NGPGUI:
                             'to_cpu': False, 'to_numpy': False,
                             'T_threshold': 1e-2,
                             'exposure': torch.cuda.FloatTensor([self.exposure]),
-                            'max_samples': 100,
+                            'max_samples': 1024,
                             'exp_step_factor': exp_step_factor})
 
         rgb = rearrange(results["rgb"], "(h w) c -> h w c", h=self.H)

--- a/sweep_config.yaml
+++ b/sweep_config.yaml
@@ -1,0 +1,8 @@
+method: grid
+parameters:
+  batch_size:
+    values: [4096, 8192]
+  num_epochs:
+    values: [20, 30]
+  lr:
+    values: [0.001, 0.01]

--- a/sweep_config.yaml
+++ b/sweep_config.yaml
@@ -1,8 +1,29 @@
-method: grid
+program: train.py 
+method: bayes
+metric:
+  name: test/psnr
+  goal: maximize
 parameters:
-  batch_size:
-    values: [4096, 8192]
-  num_epochs:
-    values: [20, 30]
   lr:
-    values: [0.001, 0.01]
+    distribution: uniform
+    min: 0.00001
+    max: 0.1
+  batch_size:
+    values: [4096, 8192, 16384]
+  num_epochs:
+    values: [20, 30, 40]
+  scale:
+    distribution: uniform
+    min: 0.1
+    max: 1.0
+  distortion_loss_w:
+    distribution: uniform
+    min: 0.0
+    max: 0.01
+command:
+  - ${env}
+  - ${interpreter}
+  - ${program}
+  - ${args}
+  - --use_sweep
+  - --root_dir=data/scannet_official/scans/scene0000_00

--- a/sweep_config.yaml
+++ b/sweep_config.yaml
@@ -20,6 +20,7 @@ parameters:
     distribution: uniform
     min: 0.0
     max: 0.01
+project: NeRFusion
 command:
   - ${env}
   - ${interpreter}

--- a/train.py
+++ b/train.py
@@ -299,7 +299,7 @@ if __name__ == '__main__':
                           save_poses=hparams.optimize_ext)
         torch.save(ckpt_, f'ckpts/{hparams.dataset_name}/{hparams.exp_name}/epoch={hparams.num_epochs-1}_slim.ckpt')
 
-    if not hparams.no_save_test:  # save video
+    if not hparams.no_save_test and hparams.save_video:  # we don't save videos for now
         imgs = sorted(glob.glob(os.path.join(system.val_dir, '*.png')))
         rgb_video_path = os.path.join(system.val_dir, 'rgb.mp4')
         depth_video_path = os.path.join(system.val_dir, 'depth.mp4')

--- a/train.py
+++ b/train.py
@@ -262,18 +262,15 @@ class NeRFSystem(LightningModule):
 if __name__ == '__main__':
     hparams = get_opts()
 
-    print(f'use debug: {hparams.debug}')
-    print(f'use dataset: {hparams.dataset_name}')
-    print(f'use dataset: {hparams.root_dir}')
-
     if not hparams.debug:
         wandb.init(project="Nerfusion", name=hparams.exp_name)
         
         if hparams.use_sweep:
             # Override hyperparameters with wandb sweep config
             wandb_config = wandb.config
-            for key in wandb_config:
-                setattr(hparams, key, wandb_config[key])
+            for key, value in wandb_config.items():
+                if hasattr(hparams, key):
+                    setattr(hparams, key, value)
     
     if hparams.val_only and (not hparams.ckpt_path):
         raise ValueError('You need to provide a @ckpt_path for validation!')


### PR DESCRIPTION
- Added logging of rendered test images after each run
- Added hyperparameter tuning with sweep api
- Added --debug option. When used, nothing gets logged and we are not polluting our project
- Added num_frames_train and num_frames_test to args, removed hardcoded values from scannet.py
- Improved initial radius for GUI and radius of train poses